### PR TITLE
Avoid possible issues when storing binary data

### DIFF
--- a/lib/ambry/adapters/file.rb
+++ b/lib/ambry/adapters/file.rb
@@ -25,12 +25,13 @@ module Ambry
       end
 
       def import_data
-        Marshal.load(::File.read(file_path))
+        data = ::File.open(file_path, "rb") { |f| f.read }
+        Marshal.load(data)
       end
 
       def save_database
         @lock.synchronize do
-          ::File.open(file_path, "w") {|f| f.write(export_data)}
+          ::File.open(file_path, "wb") {|f| f.write(export_data)}
         end
       end
     end


### PR DESCRIPTION
This could be raised due encoding mismatch between the interpreter that stored the file and the interpreter that read the file.
