### PR TITLE
adapter name clash with default 'main' adapter

### DIFF
--- a/spec/file_adapter_spec.rb
+++ b/spec/file_adapter_spec.rb
@@ -24,6 +24,16 @@ classes.each do |klass|
       FileUtils.rm_f @path
     end
 
+    describe "name" do
+      it "should be set" do
+        @adapter.name.wont_be_nil
+      end
+
+      it "should not clash with default adapter name" do
+        @adapter.name.wont_equal :main
+      end
+    end
+
     describe "#export_data" do
       it "should be a string" do
         assert_kind_of String, @adapter.export_data


### PR DESCRIPTION
Just Installed Ambry (and generated its files)

```
$ rails c
.../ambry-0.3.0/lib/ambry.rb:35:in `register_adapter': Adapter :main already registered (Ambry::AmbryError)
```

Digging the code I notice you don't set the name for File and YAML adapters, so I tried the following
in adapters/yaml.rb:

```
  def initialize(options)
    options[:name] ||= :yaml
    super
  end
```

in adapters/file.rb:

```
  def initialize(options)
    @file_path = options[:file]
    @read_only  = !! options[:read_only]
    @lock      = Mutex.new
    options[:name] ||= :file
    super
  end
```

But those changes caused a lot of errors to the specs that I couldn't trace, sorry for not providing more code.
