### PR TITLE
support Rails 5, due to https://github.com/drapergem/draper/issues/697

### DIFF
--- a/ambry.gemspec
+++ b/ambry.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "activesupport", "~> 3.0"
   s.add_development_dependency "activemodel", "~> 3.0"
+  s.add_development_dependency "activemodel-serializers-xml"
   s.add_development_dependency "rake"
 end

--- a/lib/ambry/active_model.rb
+++ b/lib/ambry/active_model.rb
@@ -1,4 +1,5 @@
 require "active_model"
+require "active_model-serializers"
 
 module Ambry
   # Extend this module if you want {Active Model}[http://github.com/rails/rails/tree/master/activemodel]


### PR DESCRIPTION
As titled, active_model/serializers/xml has been removed in Rails 5, and extracted into its own gem.

However, there is not yet a published release of activemodel-serializers-xml so far.