### PR TITLE
Prepare ambry for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 rvm:
-  - 1.9.3
-  - 1.8.7
+  - 2.3.0
   - rbx
   - jruby
-
-branches:
-  only:
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 rvm:
   - 2.3.0
   - rbx
-  - jruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-source :rubygems
+source "https://rubygems.org"
+
 gemspec

--- a/ambry.gemspec
+++ b/ambry.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
     flexible searching and storage.
   EOD
   s.add_development_dependency "ffaker"
-  s.add_development_dependency "minitest", "~> 2.2.2"
+  s.add_development_dependency "minitest", "~> 5.1"
   s.add_development_dependency "mocha"
-  s.add_development_dependency "activesupport", "~> 3.0"
-  s.add_development_dependency "activemodel", "~> 3.0"
+  s.add_development_dependency "activesupport", "~> 5.0"
+  s.add_development_dependency "activemodel", "~> 5.0"
   s.add_development_dependency "rake"
 end

--- a/ambry.gemspec
+++ b/ambry.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   EOD
   s.add_development_dependency "ffaker"
   s.add_development_dependency "minitest", "~> 5.1"
-  s.add_development_dependency "mocha"
   s.add_development_dependency "activesupport", "~> 5.0"
   s.add_development_dependency "activemodel", "~> 5.0"
   s.add_development_dependency "rake"

--- a/lib/ambry/active_model.rb
+++ b/lib/ambry/active_model.rb
@@ -14,7 +14,6 @@ module Ambry
         extend  ::ActiveModel::Translation
         include ::ActiveModel::Validations
         include ::ActiveModel::Serializers::JSON
-        include ::ActiveModel::Serializers::Xml
         extend  ::ActiveModel::Callbacks
         define_model_callbacks :save, :destroy
       end

--- a/lib/ambry/adapters/yaml.rb
+++ b/lib/ambry/adapters/yaml.rb
@@ -6,7 +6,7 @@ module Ambry
     class YAML < File
 
       def import_data
-        data = ::YAML.load(::File.read(file_path))
+        ::YAML.load(::File.read(file_path))
       end
 
       def export_data

--- a/spec/active_model_spec.rb
+++ b/spec/active_model_spec.rb
@@ -81,7 +81,7 @@ describe Ambry::ActiveModel do
     it "should serialize" do
       json = @model.to_json
       refute_nil @model.to_json
-      assert_match /"author":"Leo Tolstoy"/, json
+      assert_match(/"author":"Leo Tolstoy"/, json)
     end
   end
 

--- a/spec/active_model_spec.rb
+++ b/spec/active_model_spec.rb
@@ -85,14 +85,6 @@ describe Ambry::ActiveModel do
     end
   end
 
-  describe "#to_xml" do
-    it "should serialize to XML" do
-      xml = @model.to_xml
-      refute_nil xml
-      assert_match /<author>Leo Tolstoy<\/author>/, xml
-    end
-  end
-
   describe "#valid?" do
     it "should do validation" do
       book = Book.new

--- a/spec/file_adapter_spec.rb
+++ b/spec/file_adapter_spec.rb
@@ -33,7 +33,7 @@ classes.each do |klass|
     describe "#save_database" do
       it "should write the data to disk" do
         assert @adapter.save_database
-        assert File.exists? @path
+        assert File.exist? @path
       end
 
       it "should raise an AmbryError if it's read-only" do

--- a/spec/mapper_spec.rb
+++ b/spec/mapper_spec.rb
@@ -62,12 +62,12 @@ describe Ambry::Mapper do
       end
 
       it "should set value#to_hash as value for key" do
-        value = Person.mapper[:bogus] = Value.new(:a => "b")
+        Person.mapper[:bogus] = Value.new(:a => "b")
         assert_equal "b", Person.mapper[:bogus][:a]
       end
 
       it "should freeze the value" do
-        value = Person.mapper[:bogus] = Value.new(:a => "b")
+        Person.mapper[:bogus] = Value.new(:a => "b")
         assert Person.mapper[:bogus].frozen?
       end
     end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,7 +1,6 @@
 require File.expand_path("../spec_helper", __FILE__)
 
 describe Ambry::Model do
-
   before { load_fixtures }
   after  { Ambry.adapters.clear }
 
@@ -34,14 +33,21 @@ describe Ambry::Model do
 
     # This means your custom accessors will be invoked.
     it "invokes attr writers" do
-      Person.any_instance.expects(:name=).once
-      Person.new(:name => "joe")
+      class Person
+        def name=(val); @name = "doe"; end
+      end
+      p = Person.new(:name => "joe")
+      class Person
+        def name=(val); @name = val; end
+      end
+
+      assert_equal "doe", p.name
     end
 
     # Don't loop through params that potentially came from the Internet,
     # because we need to cast keys to Symbol, and that could leak memory.
     it "iterates over attribute names, not params" do
-      Person.attribute_names.expects(:each)
+      assert_send([Person.attribute_names, :each])
       Person.new(:name => "joe")
     end
   end
@@ -161,7 +167,7 @@ describe Ambry::Model do
   describe "#save" do
     it "passes itself to Mapper#put" do
       p = Person.new(:name => "hello")
-      Person.mapper.expects(:put)
+      assert_send([Person.mapper, :put, p])
       p.save
     end
   end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -23,8 +23,8 @@ describe Ambry::Model do
     end
 
     it "calls the block after setting sttributes" do
-      p = Person.new(:name => "foo") {|p| p.name = "bar"}
-      assert_equal "bar", p.name
+      person = Person.new(:name => "foo") {|p| p.name = "bar"}
+      assert_equal "bar", person.name
     end
 
     it "can set attributes from a hash" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require "bundler/setup"
 require "ambry"
 require "ambry/adapters/yaml"
 require 'minitest/spec'
-require "mocha"
 require "fileutils"
 require "ffaker"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,4 +39,4 @@ def load_fixtures
   Person.use :main
 end
 
-MiniTest::Unit.autorun
+MiniTest.autorun


### PR DESCRIPTION
* Drop `ActiveModel::Serializers::Xml`
* Fix tests for new minitest
* Simplify Travis CI matrix
* Drops mocha
* Fix Ruby and libraries warnings