### PR TITLE
♻️ Change ActiveModel::Errors[]#<< to ActiveModel::Errors#add

### DIFF
--- a/lib/ambry/active_model.rb
+++ b/lib/ambry/active_model.rb
@@ -27,15 +27,19 @@ module Ambry
           return if record.persisted?
           if attribute.to_sym == record.class.id_method
             begin
-              if record.class.mapper[value]
-                record.errors[attribute] << "must be unique"
-              end
+              add_to_errors(record, attribute) if record.class.mapper[value]
             rescue Ambry::NotFoundError
             end
           else
-            if record.class.all.detect {|x| x.send(attribute) == value}
-              record.errors[attribute] << "must be unique"
-            end
+            add_to_errors(record, attribute) if record.class.all.detect {|x| x.send(attribute) == value}
+          end
+        end
+
+        def add_to_errors(record, attribute)
+          if Rails.version.to_f >= 6.1
+            record.errors.add(attribute, message: "must be unique")
+          else
+            record.errors[attribute] << "must be unique"
           end
         end
       end


### PR DESCRIPTION
# Purpose

The purpose of this pull request is to fix the following warning message: 

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead
```

ActiveModel Errors are full fledged objects starting with Rails 6.1

# Backward compatibility

I introduced a conditional to ensure backward compatibility
